### PR TITLE
Lighting decor not working

### DIFF
--- a/src/LightsOut/LightsOutPatches.cs
+++ b/src/LightsOut/LightsOutPatches.cs
@@ -98,9 +98,9 @@ namespace LightsOut
 		{
 			public static void Postfix(int cell, ref int __result)
 			{
+				__result = 0;
 				if (Grid.LightIntensity[cell] >= ConfigManager.Config.LitDecorLux)
 					__result = TUNING.DECOR.LIT_BONUS;
-				__result = 0;
 			}
 		}
 


### PR DESCRIPTION
You were setting __result to 0 regardless of LightIntensity being >= LitDecorLux, this change sets __result to 0 first and then changes it to the LIT_BONUS if LightIntensity >= LitDeocrLux.