### PR TITLE
Optimize framerate +20 from obj alloc and GC pause

### DIFF
--- a/src/LightsOut/LightsOut.csproj
+++ b/src/LightsOut/LightsOut.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Lux.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="DupeLights.cs" />
     <Compile Include="Effects.cs" />

--- a/src/LightsOut/LightsOutPatches.cs
+++ b/src/LightsOut/LightsOutPatches.cs
@@ -173,25 +173,7 @@ namespace LightsOut
 
 						if (lux == 0)
 						{
-							var neighboringCells = new List<int>();
-
-							if (Grid.IsValidCell(Grid.CellAbove(cell))) neighboringCells.Add(Grid.CellAbove(cell));
-							if (Grid.IsValidCell(Grid.CellUpRight(cell))) neighboringCells.Add(Grid.CellUpRight(cell));
-							if (Grid.IsValidCell(Grid.CellRight(cell))) neighboringCells.Add(Grid.CellRight(cell));
-							if (Grid.IsValidCell(Grid.CellDownRight(cell))) neighboringCells.Add(Grid.CellDownRight(cell));
-							if (Grid.IsValidCell(Grid.CellBelow(cell))) neighboringCells.Add(Grid.CellBelow(cell));
-							if (Grid.IsValidCell(Grid.CellDownLeft(cell))) neighboringCells.Add(Grid.CellDownLeft(cell));
-							if (Grid.IsValidCell(Grid.CellLeft(cell))) neighboringCells.Add(Grid.CellLeft(cell));
-							if (Grid.IsValidCell(Grid.CellUpLeft(cell))) neighboringCells.Add(Grid.CellUpLeft(cell));
-
-							var light = 0;
-
-							foreach (var c in neighboringCells)
-							{
-								light += Grid.LightIntensity[c];
-							}
-
-							lux = light / neighboringCells.Count;
+							lux = Lux.NeighborAverage(cell);
 						}
 
 						var luxMapped = Math.Min(lux, config.LuxThreshold);

--- a/src/LightsOut/Lux.cs
+++ b/src/LightsOut/Lux.cs
@@ -1,0 +1,44 @@
+﻿namespace LightsOut
+{
+	public static class Lux
+	{
+		/// <summary>
+		/// Numerically computes the average lux from valid neighbors around a target cell. If there are no valid neighbors, returns zero.
+		/// </summary>
+		/// <returns>
+		/// The average lux from valid neighbors around the target cell.
+		/// </returns>
+		public static int NeighborAverage(int targetCell)
+		{
+			var count = 0;
+			var average = 0d;
+			// Aggregate lux from valid neighbor cells.
+			AggregateLux(Grid.CellAbove(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellUpRight(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellRight(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellDownRight(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellBelow(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellDownLeft(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellLeft(targetCell), ref count, ref average);
+			AggregateLux(Grid.CellUpLeft(targetCell), ref count, ref average);
+			// Truncate the fractional part because lux is measured as an integer.
+			return (int)average;
+		}
+
+		/// <summary>
+		/// Aggregates lux from a valid cell into a count and an average.
+		/// </summary>
+		/// <param name="cell">The cell to sample for lux.</param>
+		/// <param name="count">The number of lux samples collected. Incremented if the cell is valid.</param>
+		/// <param name="average">The average lux from samples collected. Updated if the cell is valid.</param>
+		private static void AggregateLux(int cell, ref int count, ref double average)
+		{
+			if (Grid.IsValidCell(cell))
+			{
+				count++;
+				// Incrementally update the average to avoid numerical overflows.
+				average += (Grid.LightIntensity[cell] - average) / count;
+			}
+		}
+	}
+}


### PR DESCRIPTION
**TLDR.** Some users have experienced framerate drops/spikes by -20; we discovered opportunities for optimizing framerate by +20.

**Background.** While panning the in-game camera, we observed sharp framerate drops by ~20 (120 downto 100 on 4k resolution). This behavior was periodic (occurred every 1s to 2s). The framerate drop by ~20 drop was also posted by the user `nets` on the Steam comments. If we toggle the mod through the `Toggle Lights Out` button on the game menu, the framerate becomes stable again (120 FPS for me) without framerate drops. Overall, it is a beautiful mod that we would love to enjoy without framerate drops.

**Performance notes.**
1. The bottleneck with the previous algorithm was primarily due to the large number of list allocations for `neighboringCells` that causes the GC to periodically pause the game for cleaning. A list was allocated for each cell in a region of tiles, and large regions of tiles change by panning the camera.
2. The cost of allocation and GC can be mitigated by reusing the algorithm data structures for all cells in a region rather than allocating new data structures for each cell.

**Solution direction.** Based on these performance notes, we implemented an algorithm that (1) avoids heap allocations by using an iterative method for computing the average and (2) reuses its data structures for a region of tiles instead of a single cell. The concrete code *change summary* for this solution are below. To verify that this solution actually improves the framerate, see the _sanity test_ section.

**Change summary.**
1. Added an optimized algorithm `Lux#NeighborAverage` (in an isolated utility class) to numerically average light from neighbors around a target cell.
2. Replaced the original algorithm `PropertyTextures#UpdateFogOfWar` with a call to `Lux#NeighborAverage`.

**Sanity test.** After refactoring the numerical algorithms and data structures to avoid object allocations, our framerate is stable and expected at 120 FPS (even while panning the in-game camera).