### PR TITLE
Fix "Oil Well - Any Water"

### DIFF
--- a/src/OilWellAnyWater/OilWellAnyWaterPatches.cs
+++ b/src/OilWellAnyWater/OilWellAnyWaterPatches.cs
@@ -25,6 +25,13 @@ namespace OilWellAnyWater
 				{
 					new ElementConverter.ConsumedElement(GameTags.AnyWater, 1f)
 				};
+
+				var conduitConsumer = go.AddOrGet<ConduitConsumer>();
+				conduitConsumer.conduitType = ConduitType.Liquid;
+				conduitConsumer.consumptionRate = 2f;
+				conduitConsumer.capacityKG = 10f;
+				conduitConsumer.capacityTag = GameTags.AnyWater;
+				conduitConsumer.wrongElementResult = ConduitConsumer.WrongElementResult.Dump;
 			}
 		}
 	}


### PR DESCRIPTION
In CS-444111 it looks like conduitConsumer on OilWellCap was added or changed, and now only accepts pure water.  This updates the patch to ensure it accepts any water again. Fixes #82.