### PR TITLE
Tested and Updated Plan Buildings Without Materials for Spaced Out

### DIFF
--- a/src/PlanBuildingsWithoutMaterials/PlanBuildingsWithoutMaterials.csproj
+++ b/src/PlanBuildingsWithoutMaterials/PlanBuildingsWithoutMaterials.csproj
@@ -80,6 +80,7 @@ echo F | xcopy /Y /S /R /Q "$(TargetDir)$(TargetName)-merged.dll" "$(SolutionDir
 if exist "$(ProjectDir)anim" xcopy /Y /R /I /E /Q  "$(ProjectDir)anim" "$(SolutionDir)..\Mods\$(TargetName)\anim"
 if exist "$(ProjectDir)previews" xcopy /Y /R /I /E /Q  "$(ProjectDir)previews" "$(SolutionDir)..\Mods\$(TargetName)\"
 if exist "$(TargetDir)Config.json" echo F | xcopy /Y /S /R /Q "$(TargetDir)Config.json" "$(SolutionDir)..\Mods\$(TargetName)\Config.json"
+if exist "$(TargetDir)mod_info.yaml" echo F | xcopy /Y /S /R /Q "$(TargetDir)mod_info.yaml" "$(SolutionDir)..\Mods\$(TargetName)\mod_info.yaml"
 
 xcopy /Y /R  /I /Q  /E "$(SolutionDir)..\Mods\$(TargetName)" "C:\Users\Cairath\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)"</PostBuildEvent>
   </PropertyGroup>

--- a/src/PlanBuildingsWithoutMaterials/mod_info.yaml
+++ b/src/PlanBuildingsWithoutMaterials/mod_info.yaml
@@ -1,0 +1,2 @@
+supportedContent: VANILLA_ID,EXPANSION1_ID
+lastWorkingBuild: 461546


### PR DESCRIPTION
This is honestly one of my favorite mods for the game so I thought I'd give it a test locally. It seems to work fine with the DLC without any code modifications so I've added a `mod_info.yaml` and the necessary MSBuild changes to copy said file into the output directory.

## Changes ##

* Tested the Plan Buildings Without Materials mod with the latest build of the Spaced Out DLC.
* Added a build step to copy the `mod_info.yaml` (if present) into the build output directory.
* Added a valid `mod_info.yaml` file to the mod source folder.